### PR TITLE
#6 - Mobile issue when tapping the payment amount-input

### DIFF
--- a/index.html
+++ b/index.html
@@ -2010,7 +2010,9 @@ void main(void) {
         pipeline.contexts[pipeline.contexts.length - 1].resizeCanvas()
 
         const optionsEl = document.getElementById('gis_options_div')
-        if (optionsEl) {
+        const isPaymentInputActive = document.activeElement && document.activeElement.matches('input.gis_payment_input')
+
+        if (optionsEl && !isPaymentInputActive) {
           optionsEl.style.display = 'none'
           optionsEl.innerHTML = ''
         }

--- a/index.html
+++ b/index.html
@@ -2012,7 +2012,9 @@ void main(void) {
         const optionsEl = document.getElementById('gis_options_div')
         const isPaymentInputActive = document.activeElement && document.activeElement.matches('input.gis_payment_input')
 
-        if (optionsEl && !isPaymentInputActive) {
+        if (optionsEl &&
+          !isPaymentInputActive // This is a bug-fix for the issue #6 (https://github.com/okTurtles/group-income-simulator/issues/6)
+        ) {
           optionsEl.style.display = 'none'
           optionsEl.innerHTML = ''
         }


### PR DESCRIPTION
closes #6 

@taoeffect 

This bug-fix hasn't actually been tested in my android phone as this project doesn't have a tool to do so (like `browserSync` in the `GI` project). So I think we can only check if the fix works after this PR is deployed to the PROD website. (But let me know if you do know a way to do the mobile device test)

But there was actually [a very similar issue](https://github.com/okTurtles/group-income/issues/1954) in the `GroupIncome` I fixed a while ago.
The cause of the issue there was that the `resize` handler didn't take into account the case where the viewport change is caused by the keyboard pane popping out on mobile-devices.
Reading through the related logic here, I felt quite confident that the issue was caused by the same reason so I pushed a fix and sent a PR. If the fix won't work after deployment I can come back to fixing again.
